### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -8,7 +8,6 @@ paper:
     - name: Rene Larisch
       ORCID: 0000-0003-3544-0631
   reference: >
-    ReScience C (2019) 5, 3, 2
     http://rescience.github.io/bibliography/Larisch_2019.html
 
 manifest:

--- a/codecheck.yml
+++ b/codecheck.yml
@@ -7,8 +7,7 @@ paper:
   authors:
     - name: Rene Larisch
       ORCID: 0000-0003-3544-0631
-  reference: >
-    http://rescience.github.io/bibliography/Larisch_2019.html
+  reference: https://doi.org/10.5281/zenodo.3538217
 
 manifest:
   - file: codecheck/figures/Fig1_clamp.png


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)